### PR TITLE
READMEにプロジェクトの説明を記述

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ## 特徴
 - [Kotlin Multiplatform](https://www.jetbrains.com/help/kotlin-multiplatform-dev/get-started.html)を利用
 
-### Android版のビルド方法
+## Android版のビルド方法
 - on macOS/Linux
   ```shell
   ./gradlew :composeApp:assembleDebug
@@ -17,7 +17,7 @@
   .\gradlew.bat :composeApp:assembleDebug
   ```
 
-### iOS版のビルド方法
+## iOS版のビルド方法
 iOSアプリの開発版をビルドして実行するには、次のいずれかの方法を使用します。
 - IDEのツールバーにある**実行ウィジェット（Run Widget）**から、対象の実行構成を選択して実行する
 - Xcodeで [/iosApp](./iosApp) ディレクトリを開き、Xcode上から実行する


### PR DESCRIPTION
## GitHub Issue
なし

## 概要
- README.mdを日本語化し、プロジェクト「さんすうキッズ」の説明を追加
- 不要な技術的な説明を削除し、プロジェクト概要とビルド方法に焦点を当てた内容に変更

## 変更内容

### 追加された内容
- プロジェクトの概要説明（「幼児向け算数アプリ」という明確な説明）
- 仕様書（spec.md）へのリンク
- プロジェクトの特徴としてKotlin Multiplatformの使用を記載

### 削除された内容
- KMPの詳細な技術説明（composeAppディレクトリの構造、commonMain/iosMain/jvmMainの説明）
- iosAppディレクトリの技術的な説明
- Kotlin Multiplatformの学習リンク

### 改善された内容
- Androidビルド方法のセクションを日本語化
- iOSビルド方法のセクションを日本語化し、より具体的な説明に変更
- 全体的にシンプルで読みやすい構成に変更

## 影響範囲
- ドキュメント（README.md）のみ
- コードベースへの影響なし