### PR TITLE
レベル選択画面の実装（Android）

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-ja/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ja/strings.xml
@@ -10,4 +10,8 @@
     <string name="mode_multiplication">かけざん</string>
     <string name="mode_division">わりざん</string>
     <string name="mode_all">すべて</string>
+    <string name="level_selection_title">レベルをえらんでね</string>
+    <string name="level_easy">かんたん</string>
+    <string name="level_normal">ふつう</string>
+    <string name="level_difficult">むずかしい</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -10,4 +10,8 @@
     <string name="mode_multiplication">Multiplication</string>
     <string name="mode_division">Division</string>
     <string name="mode_all">All</string>
+    <string name="level_selection_title">Select Level</string>
+    <string name="level_easy">Easy</string>
+    <string name="level_normal">Normal</string>
+    <string name="level_difficult">Difficult</string>
 </resources>

--- a/composeApp/src/commonMain/kotlin/com/vitantonio/nagauzzi/sansuukids/model/Level.kt
+++ b/composeApp/src/commonMain/kotlin/com/vitantonio/nagauzzi/sansuukids/model/Level.kt
@@ -1,0 +1,10 @@
+package com.vitantonio.nagauzzi.sansuukids.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+enum class Level {
+    EASY,
+    NORMAL,
+    DIFFICULT
+}

--- a/composeApp/src/commonMain/kotlin/com/vitantonio/nagauzzi/sansuukids/model/Mode.kt
+++ b/composeApp/src/commonMain/kotlin/com/vitantonio/nagauzzi/sansuukids/model/Mode.kt
@@ -1,0 +1,12 @@
+package com.vitantonio.nagauzzi.sansuukids.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+enum class Mode {
+    ADDITION,
+    SUBTRACTION,
+    MULTIPLICATION,
+    DIVISION,
+    ALL
+}

--- a/composeApp/src/commonMain/kotlin/com/vitantonio/nagauzzi/sansuukids/navigation/NavigationEntryProvider.kt
+++ b/composeApp/src/commonMain/kotlin/com/vitantonio/nagauzzi/sansuukids/navigation/NavigationEntryProvider.kt
@@ -1,10 +1,13 @@
 package com.vitantonio.nagauzzi.sansuukids.navigation
 
 import androidx.navigation3.runtime.NavEntry
-import com.vitantonio.nagauzzi.sansuukids.navigation.key.SansuuKidsRoute
+import com.vitantonio.nagauzzi.sansuukids.model.Mode
 import com.vitantonio.nagauzzi.sansuukids.navigation.key.HomeRoute
+import com.vitantonio.nagauzzi.sansuukids.navigation.key.LevelSelectionRoute
 import com.vitantonio.nagauzzi.sansuukids.navigation.key.ModeSelectionRoute
+import com.vitantonio.nagauzzi.sansuukids.navigation.key.SansuuKidsRoute
 import com.vitantonio.nagauzzi.sansuukids.ui.screen.HomeScreen
+import com.vitantonio.nagauzzi.sansuukids.ui.screen.LevelSelectionScreen
 import com.vitantonio.nagauzzi.sansuukids.ui.screen.ModeSelectionScreen
 
 internal fun navigationEntryProvider(
@@ -22,11 +25,19 @@ internal fun navigationEntryProvider(
 
         ModeSelectionRoute -> NavEntry(key) {
             ModeSelectionScreen(
-                onAdditionClick = { /* TODO: Navigate to Level Selection */ },
-                onSubtractionClick = { /* TODO: Navigate to Level Selection */ },
-                onMultiplicationClick = { /* TODO: Navigate to Level Selection */ },
-                onDivisionClick = { /* TODO: Navigate to Level Selection */ },
-                onAllClick = { /* TODO: Navigate to Level Selection */ }
+                onAdditionClick = { navigationState.navigateTo(LevelSelectionRoute(Mode.ADDITION)) },
+                onSubtractionClick = { navigationState.navigateTo(LevelSelectionRoute(Mode.SUBTRACTION)) },
+                onMultiplicationClick = { navigationState.navigateTo(LevelSelectionRoute(Mode.MULTIPLICATION)) },
+                onDivisionClick = { navigationState.navigateTo(LevelSelectionRoute(Mode.DIVISION)) },
+                onAllClick = { navigationState.navigateTo(LevelSelectionRoute(Mode.ALL)) }
+            )
+        }
+
+        is LevelSelectionRoute -> NavEntry(key) {
+            LevelSelectionScreen(
+                onEasyClick = { /* TODO: Navigate to Quiz with key.mode and Level.EASY */ },
+                onNormalClick = { /* TODO: Navigate to Quiz with key.mode and Level.NORMAL */ },
+                onDifficultClick = { /* TODO: Navigate to Quiz with key.mode and Level.DIFFICULT */ }
             )
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/vitantonio/nagauzzi/sansuukids/navigation/key/LevelSelectionRoute.kt
+++ b/composeApp/src/commonMain/kotlin/com/vitantonio/nagauzzi/sansuukids/navigation/key/LevelSelectionRoute.kt
@@ -1,0 +1,7 @@
+package com.vitantonio.nagauzzi.sansuukids.navigation.key
+
+import com.vitantonio.nagauzzi.sansuukids.model.Mode
+import kotlinx.serialization.Serializable
+
+@Serializable
+internal data class LevelSelectionRoute(val mode: Mode) : SansuuKidsRoute

--- a/composeApp/src/commonMain/kotlin/com/vitantonio/nagauzzi/sansuukids/ui/screen/LevelSelectionScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/vitantonio/nagauzzi/sansuukids/ui/screen/LevelSelectionScreen.kt
@@ -1,0 +1,99 @@
+package com.vitantonio.nagauzzi.sansuukids.ui.screen
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeContentPadding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.vitantonio.nagauzzi.sansuukids.ui.component.LargeButton
+import com.vitantonio.nagauzzi.sansuukids.ui.theme.SansuuKidsTheme
+import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
+import sansuukids.composeapp.generated.resources.Res
+import sansuukids.composeapp.generated.resources.level_difficult
+import sansuukids.composeapp.generated.resources.level_easy
+import sansuukids.composeapp.generated.resources.level_normal
+import sansuukids.composeapp.generated.resources.level_selection_title
+
+@Composable
+fun LevelSelectionScreen(
+    onEasyClick: () -> Unit,
+    onNormalClick: () -> Unit,
+    onDifficultClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background)
+            .safeContentPadding()
+            .padding(horizontal = 32.dp, vertical = 48.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Text(
+            text = stringResource(Res.string.level_selection_title),
+            style = MaterialTheme.typography.headlineMedium,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.testTag("level_selection_title")
+        )
+
+        Spacer(modifier = Modifier.height(32.dp))
+
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            LargeButton(
+                containerColor = MaterialTheme.colorScheme.primaryContainer,
+                contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                text = stringResource(Res.string.level_easy),
+                textStyle = MaterialTheme.typography.headlineSmall,
+                onClick = onEasyClick,
+                modifier = Modifier.height(56.dp).testTag("easy_button")
+            )
+
+            LargeButton(
+                containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                text = stringResource(Res.string.level_normal),
+                textStyle = MaterialTheme.typography.headlineSmall,
+                onClick = onNormalClick,
+                modifier = Modifier.height(56.dp).testTag("normal_button")
+            )
+
+            LargeButton(
+                containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+                contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
+                text = stringResource(Res.string.level_difficult),
+                textStyle = MaterialTheme.typography.headlineSmall,
+                onClick = onDifficultClick,
+                modifier = Modifier.height(56.dp).testTag("difficult_button")
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun LevelSelectionScreenPreview() {
+    SansuuKidsTheme {
+        LevelSelectionScreen(
+            onEasyClick = {},
+            onNormalClick = {},
+            onDifficultClick = {}
+        )
+    }
+}

--- a/composeApp/src/commonTest/kotlin/com/vitantonio/nagauzzi/sansuukids/ui/screen/LevelSelectionScreenTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/vitantonio/nagauzzi/sansuukids/ui/screen/LevelSelectionScreenTest.kt
@@ -1,0 +1,76 @@
+package com.vitantonio.nagauzzi.sansuukids.ui.screen
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import com.vitantonio.nagauzzi.sansuukids.ui.theme.SansuuKidsTheme
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalTestApi::class)
+class LevelSelectionScreenTest {
+
+    @Test
+    fun かんたんボタンを押すとonEasyClickが呼ばれる() = runComposeUiTest {
+        // Given: レベル選択画面を表示し、クリック状態を追跡する
+        var clicked = false
+        setContent {
+            SansuuKidsTheme {
+                LevelSelectionScreen(
+                    onEasyClick = { clicked = true },
+                    onNormalClick = {},
+                    onDifficultClick = {}
+                )
+            }
+        }
+
+        // When: かんたんボタンをクリックする
+        onNodeWithTag("easy_button").performClick()
+
+        // Then: onEasyClickが呼ばれる
+        assertTrue(clicked)
+    }
+
+    @Test
+    fun ふつうボタンを押すとonNormalClickが呼ばれる() = runComposeUiTest {
+        // Given: レベル選択画面を表示し、クリック状態を追跡する
+        var clicked = false
+        setContent {
+            SansuuKidsTheme {
+                LevelSelectionScreen(
+                    onEasyClick = {},
+                    onNormalClick = { clicked = true },
+                    onDifficultClick = {}
+                )
+            }
+        }
+
+        // When: ふつうボタンをクリックする
+        onNodeWithTag("normal_button").performClick()
+
+        // Then: onNormalClickが呼ばれる
+        assertTrue(clicked)
+    }
+
+    @Test
+    fun むずかしいボタンを押すとonDifficultClickが呼ばれる() = runComposeUiTest {
+        // Given: レベル選択画面を表示し、クリック状態を追跡する
+        var clicked = false
+        setContent {
+            SansuuKidsTheme {
+                LevelSelectionScreen(
+                    onEasyClick = {},
+                    onNormalClick = {},
+                    onDifficultClick = { clicked = true }
+                )
+            }
+        }
+
+        // When: むずかしいボタンをクリックする
+        onNodeWithTag("difficult_button").performClick()
+
+        // Then: onDifficultClickが呼ばれる
+        assertTrue(clicked)
+    }
+}


### PR DESCRIPTION
## GitHub Issue
close #6

## 概要
モード選択画面で任意のモードを選択した後に表示されるレベル選択画面を実装しました。

## 変更内容
- レベル選択画面（LevelSelectionScreen）を新規実装
  - かんたん、ふつう、むずかしいの3つのレベルを選択できるボタンを表示
  - ModeSelectionScreenと同じレイアウトパターンを採用
- Mode enumを新規追加
  - ADDITION, SUBTRACTION, MULTIPLICATION, DIVISION, ALLの5つのモードを定義
  - LevelSelectionRouteのパラメータとして使用
- Level enumを新規追加
  - EASY, NORMAL, DIFFICULTの3つのレベルを定義
  - 今後のQuiz画面実装で使用予定
- LevelSelectionRouteを新規追加
  - data classとしてモードパラメータを保持
  - NavigationEntryProviderでisパターンマッチングを使用
- NavigationEntryProviderを更新
  - モード選択からレベル選択への遷移を実装
  - 各モードボタンに対応するMode enumを渡す
- 日本語・英語のリソース文字列を追加
- テストを追加
  - LevelSelectionScreenTest: 3つのボタンクリックテスト
  - NavigationIntegrationTest: 画面遷移と戻るナビゲーションのテスト

## 影響範囲
- UIレイヤー（composeApp）
  - LevelSelectionScreen.kt: 新規追加
  - NavigationEntryProvider.kt: LevelSelectionRouteの追加、モード選択からの遷移実装
- ナビゲーション
  - LevelSelectionRoute.kt: 新規追加
- モデル
  - Mode.kt: 新規追加
  - Level.kt: 新規追加
- リソース
  - strings.xml（日本語・英語）: レベル選択画面の文字列追加
- テスト
  - LevelSelectionScreenTest.kt: 新規追加
  - NavigationIntegrationTest.kt: レベル選択関連のテスト追加

## 動作確認項目
- [x] モード選択画面で任意のモードを押すとレベル選択画面に遷移する
- [x] レベル選択画面で3つのボタン（かんたん、ふつう、むずかしい）が表示される
- [x] レベル選択画面でバックキーを押すとモード選択画面に戻る
- [x] LevelSelectionScreenTestが全て成功する
- [x] NavigationIntegrationTestが全て成功する

## スクリーンショット
<img width="180" height="320" alt="Screenshot_20260112_011246" src="https://github.com/user-attachments/assets/1a0be5f3-ed81-45ab-bb07-8467e62effc3" />