### PR TITLE
ホーム画面から設定ボタンを削除し、関連するテストコードを整理

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-ja/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ja/strings.xml
@@ -3,7 +3,6 @@
     <string name="app_title">さんすう\nキッズ</string>
     <string name="start">スタート</string>
     <string name="medal_collection">メダルずかん</string>
-    <string name="settings">せってい</string>
     <string name="mode_selection_title">モードをえらんでね</string>
     <string name="mode_addition">たしざん</string>
     <string name="mode_subtraction">ひきざん</string>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -3,7 +3,6 @@
     <string name="app_title">Sansuu\nKids</string>
     <string name="start">Start</string>
     <string name="medal_collection">Medals</string>
-    <string name="settings">Settings</string>
     <string name="mode_selection_title">Select Mode</string>
     <string name="mode_addition">Addition</string>
     <string name="mode_subtraction">Subtraction</string>

--- a/composeApp/src/commonMain/kotlin/com/vitantonio/nagauzzi/sansuukids/ui/navigation/NavigationEntryProvider.kt
+++ b/composeApp/src/commonMain/kotlin/com/vitantonio/nagauzzi/sansuukids/ui/navigation/NavigationEntryProvider.kt
@@ -30,8 +30,7 @@ internal fun navigationEntryProvider(
         HomeRoute -> NavEntry(key) {
             HomeScreen(
                 onStartClick = { navigationState.navigateTo(ModeSelectionRoute) },
-                onMedalCollectionClick = { /* TODO: Navigate to Medal Collection */ },
-                onSettingsClick = { /* TODO: Navigate to Settings */ }
+                onMedalCollectionClick = { /* TODO: Navigate to Medal Collection */ }
             )
         }
 

--- a/composeApp/src/commonMain/kotlin/com/vitantonio/nagauzzi/sansuukids/ui/screen/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/vitantonio/nagauzzi/sansuukids/ui/screen/HomeScreen.kt
@@ -23,14 +23,12 @@ import org.jetbrains.compose.ui.tooling.preview.Preview
 import sansuukids.composeapp.generated.resources.Res
 import sansuukids.composeapp.generated.resources.app_title
 import sansuukids.composeapp.generated.resources.medal_collection
-import sansuukids.composeapp.generated.resources.settings
 import sansuukids.composeapp.generated.resources.start
 
 @Composable
 fun HomeScreen(
     onStartClick: () -> Unit,
     onMedalCollectionClick: () -> Unit,
-    onSettingsClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     Column(
@@ -73,15 +71,6 @@ fun HomeScreen(
                 onClick = onMedalCollectionClick,
                 modifier = Modifier.height(72.dp).testTag("medal_collection_button")
             )
-
-            LargeButton(
-                containerColor = MaterialTheme.colorScheme.tertiaryContainer,
-                contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
-                text = stringResource(Res.string.settings),
-                textStyle = MaterialTheme.typography.headlineMedium,
-                onClick = onSettingsClick,
-                modifier = Modifier.height(72.dp).testTag("settings_button")
-            )
         }
     }
 }
@@ -92,8 +81,7 @@ private fun HomeScreenPreview() {
     SansuuKidsTheme {
         HomeScreen(
             onStartClick = {},
-            onMedalCollectionClick = {},
-            onSettingsClick = {}
+            onMedalCollectionClick = {}
         )
     }
 }

--- a/composeApp/src/commonTest/kotlin/com/vitantonio/nagauzzi/sansuukids/ui/navigation/NavigationIntegrationTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/vitantonio/nagauzzi/sansuukids/ui/navigation/NavigationIntegrationTest.kt
@@ -42,7 +42,6 @@ class NavigationIntegrationTest {
         // Then: ホーム画面のボタンが全て表示され、バックスタックにはホーム画面のみが存在する
         onNodeWithTag("start_button").assertIsDisplayed()
         onNodeWithTag("medal_collection_button").assertIsDisplayed()
-        onNodeWithTag("settings_button").assertIsDisplayed()
 
         assertEquals(1, navigationState.entries.size)
         assertEquals(HomeRoute, navigationState.entries.first())

--- a/composeApp/src/commonTest/kotlin/com/vitantonio/nagauzzi/sansuukids/ui/screen/HomeScreenTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/vitantonio/nagauzzi/sansuukids/ui/screen/HomeScreenTest.kt
@@ -19,8 +19,7 @@ class HomeScreenTest {
             SansuuKidsTheme {
                 HomeScreen(
                     onStartClick = { clicked = true },
-                    onMedalCollectionClick = {},
-                    onSettingsClick = {}
+                    onMedalCollectionClick = {}
                 )
             }
         }
@@ -40,8 +39,7 @@ class HomeScreenTest {
             SansuuKidsTheme {
                 HomeScreen(
                     onStartClick = {},
-                    onMedalCollectionClick = { clicked = true },
-                    onSettingsClick = {}
+                    onMedalCollectionClick = { clicked = true }
                 )
             }
         }
@@ -50,27 +48,6 @@ class HomeScreenTest {
         onNodeWithTag("medal_collection_button").performClick()
 
         // Then: onMedalCollectionClickが呼ばれる
-        assertTrue(clicked)
-    }
-
-    @Test
-    fun せっていボタンを押すとonSettingsClickが呼ばれる() = runComposeUiTest {
-        // Given: ホーム画面を表示し、クリック状態を追跡する
-        var clicked = false
-        setContent {
-            SansuuKidsTheme {
-                HomeScreen(
-                    onStartClick = {},
-                    onMedalCollectionClick = {},
-                    onSettingsClick = { clicked = true }
-                )
-            }
-        }
-
-        // When: せっていボタンをクリックする
-        onNodeWithTag("settings_button").performClick()
-
-        // Then: onSettingsClickが呼ばれる
         assertTrue(clicked)
     }
 }


### PR DESCRIPTION
## GitHub Issue
なし（未使用処理の削除）

## 概要
ホーム画面から実装予定のない「設定」ボタンを削除し、アプリの画面構成をシンプルにしました。
現在のアプリの仕様において設定機能は不要と判断し、UI要素、文字列リソース、ナビゲーションロジック、および関連するテストコードを整理しています。

## 変更内容

### UI/UX の変更
- ホーム画面から「せってい」ボタンを削除し、ホーム画面のボタン構成を2つ（スタート、メダルずかん）に簡素化
- 設定ボタンの使用箇所のコードを削除

## 影響範囲

### 変更ファイル数
- 6ファイル（UI層2ファイル、リソース2ファイル、テスト2ファイル）

### 影響を受けるレイヤー
- **プレゼンテーション層**: ホーム画面の UI 構成
- **ナビゲーション層**: ホーム画面からのナビゲーションロジック
- **リソース層**: 多言語対応の文字列リソース
- **テスト層**: ホーム画面とナビゲーションの統合テスト

### 破壊的変更
なし（設定機能は未実装のため、既存の動作には影響なし）

## 動作確認項目
- [x] ホーム画面に「スタート」「メダルずかん」の2つのボタンのみが表示される
- [x] 「せってい」ボタンが表示されない
- [x] スタートボタンからモード選択画面へ正常に遷移できる
- [x] 全ての既存テストが成功する（`./gradlew allTests`）
- [x] ホーム画面のレイアウトが適切に表示される（iOS/Android両方）
- [x] 文字列リソースのビルドエラーがない

## その他
この変更は Clean Craftsmanship の原則に従い、YAGNI（You Aren't Gonna Need It）の考え方に基づいています。現時点で必要のない機能を削除することで、コードベースの複雑性を低減し、保守性を向上させています。

## スクリーンショット
|before|after|
|---|---|
|<img width="180" height="320" alt="image" src="https://github.com/user-attachments/assets/595f6ea2-703f-4e88-a9d4-5c96c0707fdf" />|<img width="180" height="320" alt="Screenshot_20260117_212411" src="https://github.com/user-attachments/assets/211722c1-b5e5-4a1d-b954-3f9307a539a7" />|