### PR TITLE
足し算の難易度を幼児・低学年向けに調整

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/vitantonio/nagauzzi/sansuukids/logic/GenerateQuiz.kt
+++ b/composeApp/src/commonMain/kotlin/com/vitantonio/nagauzzi/sansuukids/logic/GenerateQuiz.kt
@@ -41,14 +41,14 @@ private fun generateQuestion(mode: Mode, level: Level, random: Random): Question
 }
 
 private fun generateAddition(level: Level, random: Random): Addition {
-    val (min, max) = getRangeForLevel(level)
+    val (min, max) = getAdditionRangeForLevel(level)
     val left = random.nextInt(min, max + 1)
     val right = random.nextInt(min, max + 1)
     return Addition(left, right)
 }
 
 private fun generateSubtraction(level: Level, random: Random): Subtraction {
-    val (min, max) = getRangeForLevel(level)
+    val (min, max) = getSubtractionRangeForLevel(level)
     val a = random.nextInt(min, max + 1)
     val b = random.nextInt(min, max + 1)
     val left = maxOf(a, b)
@@ -71,7 +71,18 @@ private fun generateDivision(level: Level, random: Random): Division {
     return Division(dividend, divisor)
 }
 
-private fun getRangeForLevel(level: Level): Pair<Int, Int> = when (level) {
+// 足し算用の範囲設定
+// 足し算は答えが2桁や3桁にならないように範囲を調整
+// EASY: 答えが最大10まで(1〜5)、NORMAL: 答えが最大100まで(1〜50)、DIFFICULT: 3桁以上の計算(100〜9999)
+private fun getAdditionRangeForLevel(level: Level): Pair<Int, Int> = when (level) {
+    Level.EASY -> 1 to 5
+    Level.NORMAL -> 1 to 50
+    Level.DIFFICULT -> 100 to 9999
+}
+
+// 引き算用の範囲設定
+// EASY: 1桁同士の計算(1〜9)、NORMAL: 1〜2桁同士の計算(1〜99)、DIFFICULT: 3桁以上の計算(100〜9999)
+private fun getSubtractionRangeForLevel(level: Level): Pair<Int, Int> = when (level) {
     Level.EASY -> 1 to 9
     Level.NORMAL -> 1 to 99
     Level.DIFFICULT -> 100 to 9999
@@ -79,7 +90,7 @@ private fun getRangeForLevel(level: Level): Pair<Int, Int> = when (level) {
 
 // 掛け算は結果が大きくなりやすいため、足し算・引き算とは異なる範囲を設定
 // 割り算は掛け算と難易度を合わせるために掛け算の範囲と合わせる
-// EASY: 九九の範囲(1〜9)、NORMAL: 19の段まで(1〜19)、DIFFICULT: 二桁同士の計算(1〜99)
+// EASY: 九九の範囲(1〜9)、NORMAL: 19の段まで(1〜19)、DIFFICULT: 2桁同士の計算(1〜99)
 private fun getMultiplicationRangeForLevel(level: Level): Pair<Int, Int> = when (level) {
     Level.EASY -> 1 to 9
     Level.NORMAL -> 1 to 19

--- a/composeApp/src/commonTest/kotlin/com/vitantonio/nagauzzi/sansuukids/logic/GenerateQuizTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/vitantonio/nagauzzi/sansuukids/logic/GenerateQuizTest.kt
@@ -72,8 +72,9 @@ class GenerateQuizTest {
         })
     }
 
+    // 足し算のレベル別テスト
     @Test
-    fun EASYレベルでは1桁の数が生成される() {
+    fun 足し算のEASYレベルでは1から5の数が生成される() {
         // Given: EASYレベルとADDITIONモードを指定する
         val mode = Mode.ADDITION
         val level = Level.EASY
@@ -82,16 +83,16 @@ class GenerateQuizTest {
         // When: クイズを生成する
         val quiz = generateQuiz(mode, level)
 
-        // Then: 全問の左右オペランドが1〜9である
+        // Then: 全問の左右オペランドが1〜5である（答えが2桁にならないように）
         assertTrue(quiz.questions.all { question ->
             question is Addition &&
-                    question.leftOperand in 1..9 &&
-                    question.rightOperand in 1..9
+                    question.leftOperand in 1..5 &&
+                    question.rightOperand in 1..5
         })
     }
 
     @Test
-    fun NORMALレベルでは1から99の数が生成される() {
+    fun 足し算のNORMALレベルでは1から50の数が生成される() {
         // Given: NORMALレベルとADDITIONモードを指定する
         val mode = Mode.ADDITION
         val level = Level.NORMAL
@@ -100,16 +101,16 @@ class GenerateQuizTest {
         // When: クイズを生成する
         val quiz = generateQuiz(mode, level)
 
-        // Then: 全問の左右オペランドが1〜99である
+        // Then: 全問の左右オペランドが1〜50である（答えが3桁にならないように）
         assertTrue(quiz.questions.all { question ->
             question is Addition &&
-                    question.leftOperand in 1..99 &&
-                    question.rightOperand in 1..99
+                    question.leftOperand in 1..50 &&
+                    question.rightOperand in 1..50
         })
     }
 
     @Test
-    fun DIFFICULTレベルでは3桁以上の数が含まれる() {
+    fun 足し算のDIFFICULTレベルでは100から9999の数が生成される() {
         // Given: DIFFICULTレベルとADDITIONモードを指定する
         val mode = Mode.ADDITION
         val level = Level.DIFFICULT
@@ -123,6 +124,171 @@ class GenerateQuizTest {
             question is Addition &&
                     question.leftOperand in 100..9999 &&
                     question.rightOperand in 100..9999
+        })
+    }
+
+    // 引き算のレベル別テスト
+    @Test
+    fun 引き算のEASYレベルでは1から9の数が生成される() {
+        // Given: EASYレベルとSUBTRACTIONモードを指定する
+        val mode = Mode.SUBTRACTION
+        val level = Level.EASY
+        val generateQuiz = GenerateQuiz()
+
+        // When: クイズを生成する
+        val quiz = generateQuiz(mode, level)
+
+        // Then: 全問の左右オペランドが1〜9である
+        assertTrue(quiz.questions.all { question ->
+            question is Subtraction &&
+                    question.leftOperand in 1..9 &&
+                    question.rightOperand in 1..9
+        })
+    }
+
+    @Test
+    fun 引き算のNORMALレベルでは1から99の数が生成される() {
+        // Given: NORMALレベルとSUBTRACTIONモードを指定する
+        val mode = Mode.SUBTRACTION
+        val level = Level.NORMAL
+        val generateQuiz = GenerateQuiz()
+
+        // When: クイズを生成する
+        val quiz = generateQuiz(mode, level)
+
+        // Then: 全問の左右オペランドが1〜99である
+        assertTrue(quiz.questions.all { question ->
+            question is Subtraction &&
+                    question.leftOperand in 1..99 &&
+                    question.rightOperand in 1..99
+        })
+    }
+
+    @Test
+    fun 引き算のDIFFICULTレベルでは100から9999の数が生成される() {
+        // Given: DIFFICULTレベルとSUBTRACTIONモードを指定する
+        val mode = Mode.SUBTRACTION
+        val level = Level.DIFFICULT
+        val generateQuiz = GenerateQuiz()
+
+        // When: クイズを生成する
+        val quiz = generateQuiz(mode, level)
+
+        // Then: 全問の左右オペランドが100〜9999である
+        assertTrue(quiz.questions.all { question ->
+            question is Subtraction &&
+                    question.leftOperand in 100..9999 &&
+                    question.rightOperand in 100..9999
+        })
+    }
+
+    // 掛け算のレベル別テスト
+    @Test
+    fun 掛け算のEASYレベルでは1から9の数が生成される() {
+        // Given: EASYレベルとMULTIPLICATIONモードを指定する
+        val mode = Mode.MULTIPLICATION
+        val level = Level.EASY
+        val generateQuiz = GenerateQuiz()
+
+        // When: クイズを生成する
+        val quiz = generateQuiz(mode, level)
+
+        // Then: 全問の左右オペランドが1〜9である
+        assertTrue(quiz.questions.all { question ->
+            question is Multiplication &&
+                    question.leftOperand in 1..9 &&
+                    question.rightOperand in 1..9
+        })
+    }
+
+    @Test
+    fun 掛け算のNORMALレベルでは1から19の数が生成される() {
+        // Given: NORMALレベルとMULTIPLICATIONモードを指定する
+        val mode = Mode.MULTIPLICATION
+        val level = Level.NORMAL
+        val generateQuiz = GenerateQuiz()
+
+        // When: クイズを生成する
+        val quiz = generateQuiz(mode, level)
+
+        // Then: 全問の左右オペランドが1〜19である
+        assertTrue(quiz.questions.all { question ->
+            question is Multiplication &&
+                    question.leftOperand in 1..19 &&
+                    question.rightOperand in 1..19
+        })
+    }
+
+    @Test
+    fun 掛け算のDIFFICULTレベルでは1から99の数が生成される() {
+        // Given: DIFFICULTレベルとMULTIPLICATIONモードを指定する
+        val mode = Mode.MULTIPLICATION
+        val level = Level.DIFFICULT
+        val generateQuiz = GenerateQuiz()
+
+        // When: クイズを生成する
+        val quiz = generateQuiz(mode, level)
+
+        // Then: 全問の左右オペランドが1〜99である
+        assertTrue(quiz.questions.all { question ->
+            question is Multiplication &&
+                    question.leftOperand in 1..99 &&
+                    question.rightOperand in 1..99
+        })
+    }
+
+    // 割り算のレベル別テスト
+    @Test
+    fun 割り算のEASYレベルでは1から9の数が生成される() {
+        // Given: EASYレベルとDIVISIONモードを指定する
+        val mode = Mode.DIVISION
+        val level = Level.EASY
+        val generateQuiz = GenerateQuiz()
+
+        // When: クイズを生成する
+        val quiz = generateQuiz(mode, level)
+
+        // Then: 全問の除数と商が1〜9である
+        assertTrue(quiz.questions.all { question ->
+            question is Division &&
+                    question.divisor in 1..9 &&
+                    question.correctAnswer in 1..9
+        })
+    }
+
+    @Test
+    fun 割り算のNORMALレベルでは1から19の数が生成される() {
+        // Given: NORMALレベルとDIVISIONモードを指定する
+        val mode = Mode.DIVISION
+        val level = Level.NORMAL
+        val generateQuiz = GenerateQuiz()
+
+        // When: クイズを生成する
+        val quiz = generateQuiz(mode, level)
+
+        // Then: 全問の除数と商が1〜19である
+        assertTrue(quiz.questions.all { question ->
+            question is Division &&
+                    question.divisor in 1..19 &&
+                    question.correctAnswer in 1..19
+        })
+    }
+
+    @Test
+    fun 割り算のDIFFICULTレベルでは1から99の数が生成される() {
+        // Given: DIFFICULTレベルとDIVISIONモードを指定する
+        val mode = Mode.DIVISION
+        val level = Level.DIFFICULT
+        val generateQuiz = GenerateQuiz()
+
+        // When: クイズを生成する
+        val quiz = generateQuiz(mode, level)
+
+        // Then: 全問の除数と商が1〜99である
+        assertTrue(quiz.questions.all { question ->
+            question is Division &&
+                    question.divisor in 1..99 &&
+                    question.correctAnswer in 1..99
         })
     }
 


### PR DESCRIPTION
## 概要

- 足し算のEASYレベルで答えが11以上にならないようオペランド範囲を1〜5に調整
- 足し算のNORMALレベルで答えが101以上にならないようオペランド範囲を1〜50に調整
- 演算子ごとに専用の範囲設定関数を追加し、各演算の難易度を独立して管理
- テストを各演算子（足し算・引き算・掛け算・割り算）のレベル別に分割

## 背景

幼児や小学生低学年にとって、答えが2桁や3桁になる足し算は認知的負荷が高く、学習の妨げになる可能性があります。

この変更により、学習者の発達段階に適した難易度で算数を学べるようになります。

## 変更内容

### GenerateQuiz.kt
- `getAdditionRangeForLevel()`: 足し算専用の範囲設定関数を追加
  - EASY: 1〜5（答えが最大10）
  - NORMAL: 1〜50（答えが最大100）
  - DIFFICULT: 100〜9999（変更なし）
- `getSubtractionRangeForLevel()`: 引き算用の範囲設定関数を追加（既存の`getRangeForLevel`から分離）
- 各演算の範囲設定が独立し、今後の調整が容易に

### GenerateQuizTest.kt
- 演算子ごとにレベル別テストを分割（計12テスト）
  - 足し算: 3テスト（EASY/NORMAL/DIFFICULT）
  - 引き算: 3テスト
  - 掛け算: 3テスト
  - 割り算: 3テスト
- テスト名を明確化し、何をテストしているかが一目でわかるように改善

## Test plan

- [x] すべてのテストが成功することを確認（`./gradlew :composeApp:desktopTest`）
- [x] EASYレベルで足し算を実行し、答えが10以下になることを確認
- [x] NORMALレベルで足し算を実行し、答えが100以下になることを確認
- [x] 引き算・掛け算・割り算の難易度が変更されていないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)