### PR TITLE
プライバシーポリシーの日付を修正

### DIFF
--- a/privacy-policy.md
+++ b/privacy-policy.md
@@ -1,6 +1,6 @@
 # プライバシーポリシー
 
-最終更新日: 2025年1月25日
+最終更新日: 2026年1月25日
 
 ## はじめに
 
@@ -75,7 +75,7 @@
 
 # Privacy Policy
 
-Last Updated: January 25, 2025
+Last Updated: January 25, 2026
 
 ## Introduction
 


### PR DESCRIPTION
## GitHub Issue
#36

## 概要
プライバシーポリシーの最終更新日を正しい年に修正

## 変更内容
- プライバシーポリシーの「最終更新日」を2025年から2026年に更新
- 日本語版・英語版の両方を修正

## 影響範囲
- ドキュメントのみ（コードへの影響なし）

## 動作確認項目
- [x] プライバシーポリシーの日付が2026年1月25日になっていることを確認
