### PR TITLE
クイズ生成時に同一問題の重複を防止

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/vitantonio/nagauzzi/sansuukids/logic/GenerateQuiz.kt
+++ b/composeApp/src/commonMain/kotlin/com/vitantonio/nagauzzi/sansuukids/logic/GenerateQuiz.kt
@@ -29,10 +29,11 @@ internal class GenerateQuiz(private val totalQuestions: Int = QUIZ_SIZE) {
      */
     operator fun invoke(mode: Mode, level: Level): Quiz {
         val random = Random
-        val questions = (1..totalQuestions).map {
-            generateQuestion(mode, level, random)
+        val questions = mutableSetOf<Question>() // 問題の重複を避けるためSetを使用
+        while (questions.size < totalQuestions) {
+            questions.add(generateQuestion(mode, level, random))
         }
-        return Quiz(questions, mode, level)
+        return Quiz(questions.toList(), mode, level)
     }
 }
 

--- a/composeApp/src/commonTest/kotlin/com/vitantonio/nagauzzi/sansuukids/logic/GenerateQuizTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/vitantonio/nagauzzi/sansuukids/logic/GenerateQuizTest.kt
@@ -380,4 +380,25 @@ class GenerateQuizTest {
             question is Division && question.dividend / question.divisor == question.correctAnswer
         })
     }
+
+    @Test
+    fun 生成されたクイズに同一問題の重複がない() {
+        // Given: 全モードとレベルの組み合わせ
+        val modes = listOf(Mode.ADDITION, Mode.SUBTRACTION, Mode.MULTIPLICATION, Mode.DIVISION, Mode.ALL)
+        val levels = listOf(Level.EASY, Level.NORMAL, Level.DIFFICULT)
+        val generateQuiz = GenerateQuiz()
+
+        // When/Then: 各組み合わせでクイズを生成し、重複がないことを確認
+        modes.forEach { mode ->
+            levels.forEach { level ->
+                val quiz = generateQuiz(mode, level)
+                val distinctQuestions = quiz.questions.distinct()
+                assertEquals(
+                    quiz.questions.size,
+                    distinctQuestions.size,
+                    "Mode: $mode, Level: $level で重複問題が発生"
+                )
+            }
+        }
+    }
 }


### PR DESCRIPTION
## GitHub Issue
なし

## 概要
クイズ生成時に同じ問題が複数回出題されないように修正しました。通常の算数テストでは同じ問題が重複することはないため、より現実的なテスト体験を提供します。

## 変更内容
- `GenerateQuiz.invoke()`の問題生成ロジックを`List`から`Set`ベースに変更
- 重複する問題は自動的に排除され、10問の一意な問題が生成されるまで繰り返し生成
- 全モード×全レベルの組み合わせで重複がないことを検証するテストを追加

## 影響範囲
- `composeApp/logic/GenerateQuiz.kt`: クイズ生成ロジック
- `composeApp/logic/GenerateQuizTest.kt`: テストファイル

## 動作確認項目
- [x] 全てのテストが成功すること
- [x] 各モード（足し算、引き算、掛け算、割り算、全て）でクイズを生成し、重複問題がないこと
- [x] 各レベル（かんたん、ふつう、むずかしい）で問題なく10問生成されること