### PR TITLE
iOSアプリのバンドルIDを修正

### DIFF
--- a/iosApp/Configuration/Config.xcconfig
+++ b/iosApp/Configuration/Config.xcconfig
@@ -1,7 +1,7 @@
 TEAM_ID=
 
 PRODUCT_NAME=SansuuKids
-PRODUCT_BUNDLE_IDENTIFIER=com.vitantonio.nagauzzi.sansuukids.SansuuKids$(TEAM_ID)
+PRODUCT_BUNDLE_IDENTIFIER=com.vitantonio.nagauzzi.sansuukids$(TEAM_ID)
 
 CURRENT_PROJECT_VERSION=3
 MARKETING_VERSION=0.1.2


### PR DESCRIPTION
## GitHub Issue
<!-- close/fix/resolve #1 のように書く -->

## 概要
iOSアプリのバンドル識別子（PRODUCT_BUNDLE_IDENTIFIER）に重複していた`.SansuuKids`を削除し、正しい形式に修正しました。

## 変更内容
- `PRODUCT_BUNDLE_IDENTIFIER`から重複していた`.SansuuKids`サフィックスを削除
  - 変更前: `com.vitantonio.nagauzzi.sansuukids.SansuuKids$(TEAM_ID)`
  - 変更後: `com.vitantonio.nagauzzi.sansuukids$(TEAM_ID)`
- ファイル末尾に改行を追加（コード品質の向上）

## 影響範囲
- iOSアプリのビルド設定（`iosApp/Configuration/Config.xcconfig`）
- iOSアプリのバンドル識別子

## 動作確認項目
- [ ] iOSアプリが正常にビルドできることを確認
- [ ] iOSシミュレータでアプリが正常に起動することを確認

## スクリーンショット
<!-- 設定ファイルの変更のため、スクリーンショットは不要 -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)