### PR TITLE
ホーム画面に横向きレイアウトを追加

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/vitantonio/nagauzzi/sansuukids/ui/screen/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/vitantonio/nagauzzi/sansuukids/ui/screen/HomeScreen.kt
@@ -3,7 +3,10 @@ package com.vitantonio.nagauzzi.sansuukids.ui.screen
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -11,12 +14,14 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeContentPadding
 import androidx.compose.foundation.layout.sizeIn
+import androidx.compose.foundation.layout.width
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.vitantonio.nagauzzi.sansuukids.ui.component.LargeButton
 import com.vitantonio.nagauzzi.sansuukids.ui.theme.SansuuKidsTheme
@@ -37,11 +42,38 @@ fun HomeScreen(
     onSettingsClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    Column(
+    BoxWithConstraints(
         modifier = modifier
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.background)
             .safeContentPadding()
+    ) {
+        if (maxWidth > maxHeight) {
+            HomeScreenLandscape(
+                onStartClick = onStartClick,
+                onMedalCollectionClick = onMedalCollectionClick,
+                onSettingsClick = onSettingsClick
+            )
+        } else {
+            HomeScreenPortrait(
+                onStartClick = onStartClick,
+                onMedalCollectionClick = onMedalCollectionClick,
+                onSettingsClick = onSettingsClick
+            )
+        }
+    }
+}
+
+@Composable
+private fun HomeScreenPortrait(
+    onStartClick: () -> Unit,
+    onMedalCollectionClick: () -> Unit,
+    onSettingsClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
             .padding(horizontal = 32.dp, vertical = 48.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center
@@ -50,44 +82,99 @@ fun HomeScreen(
             painter = painterResource(Res.drawable.app_icon),
             contentDescription = stringResource(Res.string.app_title),
             modifier = Modifier
-                .fillMaxWidth()
+                .weight(2f)
                 .sizeIn(maxWidth = 400.dp, maxHeight = 400.dp)
                 .aspectRatio(1f)
                 .testTag("home_title"),
             contentScale = ContentScale.Fit
         )
 
-        Column(
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(24.dp)
-        ) {
-            LargeButton(
-                containerColor = MaterialTheme.colorScheme.primaryContainer,
-                contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-                text = stringResource(Res.string.start),
-                textStyle = MaterialTheme.typography.headlineMedium,
-                onClick = onStartClick,
-                modifier = Modifier.height(72.dp).testTag("start_button")
-            )
+        HomeButtons(
+            onStartClick = onStartClick,
+            onMedalCollectionClick = onMedalCollectionClick,
+            onSettingsClick = onSettingsClick,
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxWidth()
+        )
+    }
+}
 
-            LargeButton(
-                containerColor = MaterialTheme.colorScheme.secondaryContainer,
-                contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
-                text = stringResource(Res.string.medal_collection),
-                textStyle = MaterialTheme.typography.headlineMedium,
-                onClick = onMedalCollectionClick,
-                modifier = Modifier.height(72.dp).testTag("medal_collection_button")
-            )
+@Composable
+private fun HomeScreenLandscape(
+    onStartClick: () -> Unit,
+    onMedalCollectionClick: () -> Unit,
+    onSettingsClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(horizontal = 32.dp, vertical = 24.dp),
+        horizontalArrangement = Arrangement.SpaceEvenly,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Image(
+            painter = painterResource(Res.drawable.app_icon),
+            contentDescription = stringResource(Res.string.app_title),
+            modifier = Modifier
+                .weight(1f)
+                .sizeIn(maxWidth = 300.dp, maxHeight = 300.dp)
+                .aspectRatio(1f)
+                .testTag("home_title"),
+            contentScale = ContentScale.Fit
+        )
 
-            LargeButton(
-                containerColor = MaterialTheme.colorScheme.tertiaryContainer,
-                contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
-                text = stringResource(Res.string.settings),
-                textStyle = MaterialTheme.typography.headlineMedium,
-                onClick = onSettingsClick,
-                modifier = Modifier.height(72.dp).testTag("settings_button")
-            )
-        }
+        Spacer(modifier = Modifier.width(32.dp))
+
+        HomeButtons(
+            onStartClick = onStartClick,
+            onMedalCollectionClick = onMedalCollectionClick,
+            onSettingsClick = onSettingsClick,
+            modifier = Modifier.weight(1f)
+        )
+    }
+}
+
+@Composable
+private fun HomeButtons(
+    onStartClick: () -> Unit,
+    onMedalCollectionClick: () -> Unit,
+    onSettingsClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    spacing: Dp = 24.dp
+) {
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(spacing)
+    ) {
+        LargeButton(
+            containerColor = MaterialTheme.colorScheme.primaryContainer,
+            contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+            text = stringResource(Res.string.start),
+            textStyle = MaterialTheme.typography.headlineMedium,
+            onClick = onStartClick,
+            modifier = Modifier.height(72.dp).testTag("start_button")
+        )
+
+        LargeButton(
+            containerColor = MaterialTheme.colorScheme.secondaryContainer,
+            contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+            text = stringResource(Res.string.medal_collection),
+            textStyle = MaterialTheme.typography.headlineMedium,
+            onClick = onMedalCollectionClick,
+            modifier = Modifier.height(72.dp).testTag("medal_collection_button")
+        )
+
+        LargeButton(
+            containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+            contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
+            text = stringResource(Res.string.settings),
+            textStyle = MaterialTheme.typography.headlineMedium,
+            onClick = onSettingsClick,
+            modifier = Modifier.height(72.dp).testTag("settings_button")
+        )
     }
 }
 


### PR DESCRIPTION
## GitHub Issue
<!-- 関連するIssueがあれば記載 -->

## 概要
ホーム画面でデバイスを横向きにした際に最適化されたレイアウトを表示するように改善しました。

## 変更内容
- `BoxWithConstraints`を使用して画面の縦横比を検出する機能を追加
- 縦向き用レイアウト（`HomeScreenPortrait`）を新設
- 横向き用レイアウト（`HomeScreenLandscape`）を新設
- ボタン群を`HomeButtons`コンポーネントとして共通化し、再利用性を向上

## 影響範囲
- `composeApp/src/commonMain/.../ui/screen/HomeScreen.kt`
- ホーム画面のUIレイアウトのみ（ロジックへの影響なし）

## 動作確認項目
- [ ] 縦向きでホーム画面が正しく表示されること
- [ ] 横向きでホーム画面が正しく表示されること
- [ ] 各ボタン（スタート、メダルコレクション、設定）が正しく動作すること
- [ ] 画面回転時にレイアウトが適切に切り替わること

## スクリーンショット
|Pixel 9 Pro<br />縦向き|Pixel 9 Pro<br />横向き|Pixel Tablet<br />縦向き|Pixel Tablet<br />横向き|
|---|---|---|---|
|<img width="128" height="286" alt="Screenshot_20260129_200151" src="https://github.com/user-attachments/assets/ba320e56-0c98-4963-8f91-a04c76a79c77" />|<img width="286" height="128" alt="Screenshot_20260129_200158" src="https://github.com/user-attachments/assets/db146936-e837-4793-b80f-9984f077012c" />|<img width="160" height="256" alt="Screenshot_20260129_200127" src="https://github.com/user-attachments/assets/a1c58d74-8a97-4d57-8c53-ad07a35368f9" />|<img width="256" height="160" alt="Screenshot_20260129_200142" src="https://github.com/user-attachments/assets/7b47a11d-df64-4182-a721-458c043a6bed" />|