### PR TITLE
NavigationStateの状態保存・復元機能を追加

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/vitantonio/nagauzzi/sansuukids/ui/navigation/NavigationState.kt
+++ b/composeApp/src/commonMain/kotlin/com/vitantonio/nagauzzi/sansuukids/ui/navigation/NavigationState.kt
@@ -3,9 +3,11 @@ package com.vitantonio.nagauzzi.sansuukids.ui.navigation
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.mutableStateListOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.snapshots.SnapshotStateList
 import com.vitantonio.nagauzzi.sansuukids.ui.navigation.key.SansuuKidsRoute
+import kotlinx.serialization.json.Json
 
 @Stable
 internal class NavigationState(
@@ -26,13 +28,25 @@ internal class NavigationState(
             backStack.removeLastOrNull()
         }
     }
+
+    companion object {
+        fun saver(): Saver<NavigationState, String> = Saver(
+            save = { state ->
+                Json.encodeToString(state.entries.toList())
+            },
+            restore = { json ->
+                val routes = Json.decodeFromString<List<SansuuKidsRoute>>(json)
+                NavigationState(mutableStateListOf(*routes.toTypedArray()))
+            }
+        )
+    }
 }
 
 @Composable
 internal fun rememberNavigationState(
     initialRoute: SansuuKidsRoute
 ): NavigationState {
-    return remember {
+    return rememberSaveable(saver = NavigationState.saver()) {
         NavigationState(mutableStateListOf(initialRoute))
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/vitantonio/nagauzzi/sansuukids/ui/navigation/key/SansuuKidsRoute.kt
+++ b/composeApp/src/commonMain/kotlin/com/vitantonio/nagauzzi/sansuukids/ui/navigation/key/SansuuKidsRoute.kt
@@ -1,5 +1,7 @@
 package com.vitantonio.nagauzzi.sansuukids.ui.navigation.key
 
 import androidx.navigation3.runtime.NavKey
+import kotlinx.serialization.Serializable
 
+@Serializable
 internal sealed interface SansuuKidsRoute : NavKey

--- a/composeApp/src/commonTest/kotlin/com/vitantonio/nagauzzi/sansuukids/ui/navigation/NavigationStateTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/vitantonio/nagauzzi/sansuukids/ui/navigation/NavigationStateTest.kt
@@ -1,11 +1,16 @@
 package com.vitantonio.nagauzzi.sansuukids.ui.navigation
 
 import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.saveable.SaverScope
+import com.vitantonio.nagauzzi.sansuukids.model.Level
+import com.vitantonio.nagauzzi.sansuukids.model.Mode
 import com.vitantonio.nagauzzi.sansuukids.ui.navigation.key.HomeRoute as TestRouteA
 import com.vitantonio.nagauzzi.sansuukids.ui.navigation.key.ModeSelectionRoute as TestRouteB
+import com.vitantonio.nagauzzi.sansuukids.ui.navigation.key.QuizRoute
 import com.vitantonio.nagauzzi.sansuukids.ui.navigation.key.SansuuKidsRoute
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 
 class NavigationStateTest {
@@ -120,5 +125,48 @@ class NavigationStateTest {
         // Then: ルートは変わらない
         assertEquals(1, navigationState.entries.size)
         assertEquals(TestRouteA, navigationState.entries[0])
+    }
+
+    @Test
+    fun NavigationStateを保存して復元できる() {
+        // Given: 複数のルートを持つNavigationStateを作成する
+        val backStack = mutableStateListOf(
+            TestRouteA,
+            TestRouteB,
+            QuizRoute(Mode.ADDITION, Level.EASY)
+        )
+        val originalState = NavigationState(backStack)
+        val saver = NavigationState.saver()
+
+        // When: 保存して復元する
+        val saved = with(saver) { SaverScope { true }.save(originalState) }
+        assertNotNull(saved)
+        val restoredState = saver.restore(saved)
+
+        // Then: 復元されたStateが元のStateと同じエントリを持つ
+        assertNotNull(restoredState)
+        assertEquals(3, restoredState.entries.size)
+        assertEquals(TestRouteA, restoredState.entries[0])
+        assertEquals(TestRouteB, restoredState.entries[1])
+        val quizRoute = restoredState.entries[2] as QuizRoute
+        assertEquals(Mode.ADDITION, quizRoute.mode)
+        assertEquals(Level.EASY, quizRoute.level)
+    }
+
+    @Test
+    fun 空のバックスタックを保存して復元できる() {
+        // Given: 空のバックスタックを持つNavigationStateを作成する
+        val backStack = mutableStateListOf<SansuuKidsRoute>()
+        val originalState = NavigationState(backStack)
+        val saver = NavigationState.saver()
+
+        // When: 保存して復元する
+        val saved = with(saver) { SaverScope { true }.save(originalState) }
+        assertNotNull(saved)
+        val restoredState = saver.restore(saved)
+
+        // Then: 復元されたStateが空のエントリを持つ
+        assertNotNull(restoredState)
+        assertEquals(0, restoredState.entries.size)
     }
 }


### PR DESCRIPTION
## GitHub Issue
close #53

## 概要
NavigationStateをConfiguration Change（画面回転など）を経ても保持できるようにする機能を追加しました。

## 変更内容
- `SansuuKidsRoute`に`@Serializable`アノテーションを追加
- `NavigationState.saver()`を実装し、JSON形式でバックスタックを保存・復元可能にした
- `remember`を`rememberSaveable`に変更し、状態の永続化に対応
- Saver機能のユニットテストを追加

## 影響範囲
- Navigation層（`NavigationState`、`SansuuKidsRoute`）

## 動作確認項目
- [x] 画面回転後もナビゲーション状態が保持されることを確認
- [x] アプリをバックグラウンドに移動し、復帰後もナビゲーション状態が保持されることを確認
- [x] クイズ画面で画面回転してもModeとLevelが保持されることを確認
- [x] テストが通ることを確認

## スクリーンショット
<!-- 必要に応じて静止画もしくは動画を添付 -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)