### PR TITLE
AndroidアプリをFullscreenモードに変更

### DIFF
--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -7,7 +7,7 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@android:style/Theme.Material.Light.NoActionBar">
+        android:theme="@android:style/Theme.Material.Light.NoActionBar.Fullscreen">
         <activity
             android:exported="true"
             android:name=".MainActivity">


### PR DESCRIPTION
## GitHub Issue
なし

## 概要
AndroidアプリをFullscreenモードで表示するように変更

## 変更内容
- AndroidManifest.xmlのテーマを`Theme.Material.Light.NoActionBar`から`Theme.Material.Light.NoActionBar.Fullscreen`に変更
- ステータスバーとナビゲーションバーを非表示にし、画面全体を使用するように変更

## 影響範囲
- Androidアプリ全体のUI表示

## 動作確認項目
- [x] Androidエミュレータ/実機でアプリがFullscreen表示されることを確認
- [x] ステータスバーが非表示になっていることを確認
- [x] 全画面でコンテンツが正しく表示されることを確認
- [x] 各画面（ホーム、モード選択、レベル選択、クイズ、結果）でレイアウトが崩れていないことを確認

## スクリーンショット
<img width="128" height="286" alt="Screenshot_20260131_135223" src="https://github.com/user-attachments/assets/7ac32692-ff43-4d04-bda3-30c3c00aa8ed" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)